### PR TITLE
change-default-icon

### DIFF
--- a/resources/views/components/sidebar-link.blade.php
+++ b/resources/views/components/sidebar-link.blade.php
@@ -26,10 +26,10 @@
 			<span class="nav-link-icon d-md-none d-lg-inline-block">{!! $icon !!}</span>
         @else
             <span class="nav-link-icon d-md-none d-lg-inline-block">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-left" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                    <polyline points="15 6 9 12 15 18"></polyline>
-                </svg>
+                    <path d="M12 7a5 5 0 1 1 -4.995 5.217l-.005 -.217l.005 -.217a5 5 0 0 1 4.995 -4.783z" stroke-width="0" fill="currentColor"></path>
+                </svg> 
             </span>
 		@endisset
 		<span class="nav-link-title">{{$title}}</span>


### PR DESCRIPTION
Change default icon from chevron-left to dot, because "dot" does't matter in direction(ltr or rtl).

<img width="249" alt="Screenshot 2023-11-21 at 8 02 06 PM" src="https://github.com/sedehi/laravel-tabler/assets/46772227/66436d64-00de-4f68-b0ae-5af3321e0fe9">
To
<img width="243" alt="Screenshot 2023-11-21 at 8 07 17 PM" src="https://github.com/sedehi/laravel-tabler/assets/46772227/478f7ebe-e28d-42cd-a6b5-f3d98d825571">

